### PR TITLE
Basic login/logout

### DIFF
--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -20,6 +20,24 @@
             <v-list-item-title v-text="item.title" />
           </v-list-item-content>
         </v-list-item>
+        <client-only>
+          <v-list-item v-if="loginState" @click="logout">
+            <v-list-item-action>
+              <v-icon>mdi-account</v-icon>
+            </v-list-item-action>
+            <v-list-item-content>
+              <v-title>ログアウト</v-title>
+            </v-list-item-content>
+          </v-list-item>
+          <v-list-item v-if="!loginState" to="/login">
+            <v-list-item-action>
+              <v-icon>mdi-account</v-icon>
+            </v-list-item-action>
+            <v-list-item-content>
+              <v-title>ログイン</v-title>
+            </v-list-item-content>
+          </v-list-item>
+        </client-only>
       </v-list>
     </v-navigation-drawer>
     <v-app-bar :clipped-left="clipped" fixed app>
@@ -48,21 +66,27 @@ export default {
       items: [
         {
           icon: 'mdi-apps',
-          title: 'Welcome',
+          title: 'トップ',
           to: '/'
         },
         {
           icon: 'mdi-chart-bubble',
           title: 'ブログ',
           to: '/blogs'
-        },
-        {
-          icon: 'mdi-account',
-          title: 'Login',
-          to: '/login'
         }
       ],
-      title: 'Vuetify.js'
+      title: 'ダンサーサポート',
+      loginState: !!this.$fire.auth.currentUser
+    }
+  },
+  methods: {
+    async logout () {
+      try {
+        await this.$fire.auth.signOut()
+        this.loginState = false
+      } catch (e) {
+        alert(e)
+      }
     }
   }
 }

--- a/middleware/auth.js
+++ b/middleware/auth.js
@@ -1,0 +1,7 @@
+export default function ({ store, redirect }) {
+  if (!store.getters.isLoggedIn) {
+    return redirect('/login')
+  // } else {
+    // return redirect('/')
+  }
+}

--- a/middleware/auth.js
+++ b/middleware/auth.js
@@ -1,7 +1,9 @@
-export default function ({ store, redirect }) {
-  if (!store.getters.isLoggedIn) {
+export default function ({ store, redirect, route }) {
+  const isLoggedIn = store.getters.isLoggedIn
+  const path = route.path
+  if (!isLoggedIn && path !== '/login') {
     return redirect('/login')
-  // } else {
-    // return redirect('/')
+  } else if (isLoggedIn && path === '/login') {
+    return redirect('/')
   }
 }

--- a/pages/blogs.vue
+++ b/pages/blogs.vue
@@ -29,6 +29,7 @@ const client = createClient()
 export default {
   components: { Card },
   transition: 'slide-left',
+  // middleware: 'auth',
   asyncData: async ({ env }) => {
     try {
       const entries = await client.getEntries(env.CTF_BLOG_POST_TYPE_ID)

--- a/pages/login.vue
+++ b/pages/login.vue
@@ -1,17 +1,21 @@
 <template>
   <v-form>
     <v-container>
-      <v-text-field v-model="email" label="MailAddress" type="email" />
-      <v-text-field v-model="password" label="Password" type="password" />
-      <v-btn color="primary" @click="createUser">
-        Register
-      </v-btn>
-      <v-btn color="primary" @click="logInUser">
-        ログイン
-      </v-btn>
-      <v-btn color="primary" @click="logout">
-        ログアウト
-      </v-btn>
+      <v-main v-if="loginState">
+        <v-btn color="secondary" to="/blogs">
+          ダッシュボードへ
+        </v-btn>
+      </v-main>
+      <v-main v-if="!loginState">
+        <v-text-field v-model="email" label="メールアドレス" type="email" />
+        <v-text-field v-model="password" label="パスワード" type="password" />
+        <v-btn color="secondary" :loading="loading" :disabled="loading" @click="createUser">
+          新規登録
+        </v-btn>
+        <v-btn color="primary" :loading="loading" :disabled="loading" @click="logInUser">
+          ログイン
+        </v-btn>
+      </v-main>
     </v-container>
   </v-form>
 </template>
@@ -21,36 +25,43 @@ export default {
     return {
       email: '',
       password: '',
-      loginState: this.$fire.auth.currentUser
+      loginState: !!this.$fire.auth.currentUser,
+      loading: false
     }
   },
   middleware: 'auth',
+  scrollToTop: true,
   methods: {
     async createUser () {
       try {
+        this.loading = true
+
         await this.$fire.auth.createUserWithEmailAndPassword(
           this.email,
           this.password
         )
+
+        this.loginState = true
       } catch (e) {
         alert(e)
+      } finally {
+        this.loading = false
       }
     },
     async logInUser () {
       try {
+        this.loading = true
+
         await this.$fire.auth.signInWithEmailAndPassword(
           this.email,
           this.password
         )
+
+        this.loginState = true
       } catch (e) {
         alert(e)
-      }
-    },
-    async logout () {
-      try {
-        await this.$fire.auth.signOut()
-      } catch (e) {
-        alert(e)
+      } finally {
+        this.loading = false
       }
     }
   }

--- a/pages/login.vue
+++ b/pages/login.vue
@@ -9,6 +9,9 @@
       <v-btn color="primary" @click="logInUser">
         ログイン
       </v-btn>
+      <v-btn color="primary" @click="logout">
+        ログアウト
+      </v-btn>
     </v-container>
   </v-form>
 </template>
@@ -17,9 +20,11 @@ export default {
   data () {
     return {
       email: '',
-      password: ''
+      password: '',
+      loginState: this.$fire.auth.currentUser
     }
   },
+  middleware: 'auth',
   methods: {
     async createUser () {
       try {

--- a/store/actions.js
+++ b/store/actions.js
@@ -35,12 +35,9 @@ export default {
 
   onAuthStateChanged ({ commit }, { authUser }) {
     if (!authUser) {
-      console.log('no user found')
       commit('RESET_STORE')
       return
     }
-    console.log('authUser: ', authUser)
-
     commit('SET_AUTH_USER', { authUser })
   },
 

--- a/store/actions.js
+++ b/store/actions.js
@@ -19,12 +19,12 @@ export default {
     if (ctx.res && ctx.res.locals && ctx.res.locals.user) {
       const { allClaims: claims, ...authUser } = ctx.res.locals.user
 
-      console.info(
-        'Auth User verified on server-side. User: ',
-        authUser,
-        'Claims:',
-        claims
-      )
+      // console.info(
+      //   'Auth User verified on server-side. User: ',
+      //   authUser,
+      //   'Claims:',
+      //   claims
+      // )
 
       await dispatch('onAuthStateChanged', {
         authUser,

--- a/store/actions.js
+++ b/store/actions.js
@@ -1,3 +1,4 @@
+
 export default {
   async nuxtServerInit ({ dispatch }, ctx) {
     if (this.$fire.auth === null) {
@@ -18,12 +19,12 @@ export default {
     if (ctx.res && ctx.res.locals && ctx.res.locals.user) {
       const { allClaims: claims, ...authUser } = ctx.res.locals.user
 
-      // console.info(
-      //   'Auth User verified on server-side. User: ',
-      //   authUser,
-      //   'Claims:',
-      //   claims
-      // )
+      console.info(
+        'Auth User verified on server-side. User: ',
+        authUser,
+        'Claims:',
+        claims
+      )
 
       await dispatch('onAuthStateChanged', {
         authUser,
@@ -34,9 +35,12 @@ export default {
 
   onAuthStateChanged ({ commit }, { authUser }) {
     if (!authUser) {
+      console.log('no user found')
       commit('RESET_STORE')
       return
     }
+    console.log('authUser: ', authUser)
+
     commit('SET_AUTH_USER', { authUser })
   },
 

--- a/store/actions.js
+++ b/store/actions.js
@@ -1,4 +1,3 @@
-
 export default {
   async nuxtServerInit ({ dispatch }, ctx) {
     if (this.$fire.auth === null) {


### PR DESCRIPTION
これでログイン状況によって表示できるページの制御ができるようになりました。

# できること
- ログインタブの表示が初期レンダリング時のログイン状況に応じて「ログイン」か「ログアウト」かに分かれる
- ログインの際はログインページ（/login）に飛んで、ログインできる
- ログインボタンまたは新規登録ボタンを押すとロード中の表示に切り替わる
- ログインまたは新規登録が成功すると、ダッシュボードに飛ぶボタンが表示されてロードが終了する
- ダッシュボードに飛ぶボタンを押すと、現状ブログのページに飛ぶ
- ログアウトの際は押すとログアウトでき、タブがログインに切り替わる
- ログイン時に/loginに飛ぼうとするとトップに飛ばされる
- ログインしないと見られないページをミドルウェアの指定で設定してあげると、ログイン画面に飛ばせる

# まだできないこと
- ログイン状況のstateを共通化していないので、ログインしてもハンバーガーメニュー内のログインタブはログアウトに変わらない（リロードしたら変わる）
- まだモーダル（VuetifyのDialog）じゃない