### PR TITLE
Dependabot/change_branch_to_develop

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,10 +7,13 @@ updates:
     interval: daily
     time: '00:00'
   open-pull-requests-limit: 10
+  target-branch: "develop"
   reviewers:
-    - yuma sumi
+    - "y-yeah"
+    - "daigotanaka0714"
+    - "ryo-takaya"
   assignees:
-    - yuma sumi
+    - "y-yeah"
   commit-message:
     prefix: fix
     prefix-development: chore
@@ -22,10 +25,13 @@ updates:
     interval: daily
     time: '00:00'
   open-pull-requests-limit: 10
+  target-branch: "develop"
   reviewers:
-    - yuma sumi
+    - "y-yeah"
+    - "daigotanaka0714"
+    - "ryo-takaya"
   assignees:
-    - yuma sumi
+    - "y-yeah"
   commit-message:
     prefix: fix
     prefix-development: chore


### PR DESCRIPTION
- botの向き先をdevelopに変更
- レビューアーを指定

ref: https://github.com/dancer-support/dance-tech-main/issues/324