### PR TITLE
swaggerUIを導入

### DIFF
--- a/api_document/test_api.yaml
+++ b/api_document/test_api.yaml
@@ -1,0 +1,81 @@
+openapi: 3.0.0
+info:
+  version: 1.0.0
+  title: Sample API
+  description: >-
+    A sample API that uses a sample-site as an example to demonstrate features in
+    the OpenAPI 3.0 specification
+servers:
+  - url: 'http://localhost:8003'
+paths:
+  /users:
+    get:
+      description: >
+        Returns all users
+      operationId: findUsers
+      parameters:
+        - name: tags
+          in: query
+          description: tags to filter by
+          required: false
+          style: form
+          schema:
+            type: array
+            items:
+              type: string
+        - name: limit
+          in: query
+          description: maximum number of results to return
+          required: false
+          schema:
+            type: integer
+            format: int32
+      responses:
+        '200':
+          description: user response
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/User'
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+components:
+  schemas:
+    User:
+      type: "object"
+      required:
+        - "name"
+      properties:
+        id:
+          type: "integer"
+          format: "int64"
+          example: 100
+        name:
+          type: "string"
+          example: "Taro"
+        status:
+          type: "string"
+          description: "user status"
+          enum:
+            - "pending"
+            - "active"
+            - "inactive"
+    Error:
+      type: "object"
+      properties:
+        code:
+          type: "integer"
+          format: "int32"
+        type:
+          type: "string"
+        message:
+          type: "string"
+externalDocs:
+  description: "Find out more about Swagger"
+  url: "http://swagger.io"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,6 +41,16 @@ services:
     volumes:
       - postgres:/var/lib/postgresql/data
 
+  swagger-ui:
+    image: swaggerapi/swagger-ui
+    container_name: "swagger-ui"
+    ports:
+      - "8002:8080"
+    volumes:
+      - ./api_document/test_api.yaml:/test_api.yaml
+    environment:
+      SWAGGER_JSON: /test_api.yaml
+
 volumes:
   client_node_modules:
   api_node_modules:


### PR DESCRIPTION
## 紐づくissue
#331 

## 変更点
- swaggerUIをdockerで導入
- apiドキュメントを置く場所を作成

## 動作確認
- `docker compose up -d`のコマンドを叩く
- `http://localhost:8002`にアクセスしてswaggerUIが開けたら成功

## 今回やらない事
- swagger Editorの導入
