### PR TITLE
docker 起動したらroutesの差分が出たのでfix

### DIFF
--- a/api/src/doc/routes.ts
+++ b/api/src/doc/routes.ts
@@ -262,7 +262,7 @@ export function RegisterRoutes(app: express.Router) {
         // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
         app.get('/theaters',
 
-            function TheatersController_getPerformances(request: any, response: any, next: any) {
+            function TheatersController_getTheaters(request: any, response: any, next: any) {
             const args = {
             };
 

--- a/api/src/doc/swagger.json
+++ b/api/src/doc/swagger.json
@@ -447,7 +447,7 @@
 		},
 		"/theaters": {
 			"get": {
-				"operationId": "GetPerformances",
+				"operationId": "GetTheaters",
 				"responses": {
 					"200": {
 						"description": "Ok",
@@ -455,7 +455,7 @@
 							"application/json": {
 								"schema": {
 									"items": {
-										"$ref": "#/components/schemas/Performance"
+										"$ref": "#/components/schemas/Theater"
 									},
 									"type": "array",
 									"nullable": true


### PR DESCRIPTION
## 実現したいこと
- nitsですが、最新のdevelopでmake initすると今回の差分が出てきたので取り込んでfixしたい

## やったこと
docker 起動時に差分が発生していたので取り込みPRを作成

## 動作確認
skipしてOKです

## 注意点
none

## スクリーンショットなど

- スクリーンショットや画面録画などあれば
