### PR TITLE
pull requestでもciが走るようにする

### DIFF
--- a/.github/workflows/api.yml
+++ b/.github/workflows/api.yml
@@ -6,6 +6,7 @@ on:
       - main
       - master
       - develop
+  pull_request:
 
 jobs:
   api_lint:

--- a/.github/workflows/client.yml
+++ b/.github/workflows/client.yml
@@ -6,6 +6,7 @@ on:
       - main
       - master
       - develop
+  pull_request:
 
 jobs:
   client_lint:


### PR DESCRIPTION
## 実現したいこと

- PR出した時にci（lint）が走るようにする

## やったこと

- workflowsのyamlにpull_requestを追記

## 動作確認

- ciがPR作成時に走ればOK

## 注意点

- レビュー中・マージ後、どのような点に気をつけるべきか？

## スクリーンショットなど

- スクリーンショットや画面録画などあれば
